### PR TITLE
Fix tests

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -405,14 +405,14 @@ impl WrapArray {
 
 /// If a root-level key-value pair is to long, create the table as a separate section.
 ///
-/// ```
+/// ```toml
 /// [dependency]
 /// a = {version="0.4.1", path="some_very_long_path_to_directory", git="https://github.come/some_weird_long_repository_name"}
 /// ```
 ///
 /// to
 ///
-/// ```
+/// ```toml
 /// [dependency.a]
 /// version="0.4.1"
 /// path="some_very_long_path_to_directory"

--- a/src/toml_config.rs
+++ b/src/toml_config.rs
@@ -7,7 +7,7 @@ pub struct TomlFormatConfig {
     /// Order sections in the toml document according to the [manifest's][1] order.
     ///
     /// ## Example
-    /// ```
+    /// ```toml
     /// [[bin]]
     /// bench = false
     /// name = "cool-tool"
@@ -25,7 +25,7 @@ pub struct TomlFormatConfig {
     ///
     /// To:
     ///
-    /// ```
+    /// ```toml
     /// [package]
     /// name = "some-crate"
     /// version = "0.0.0"
@@ -54,7 +54,7 @@ pub struct TomlFormatConfig {
 
     /// Order the package section items according to the [manifest's][1] order.
     ///
-    /// ```
+    /// ```toml
     /// [package]
     /// version = "0.0.0"
     /// rust-version = "1.6.3.0"
@@ -64,7 +64,7 @@ pub struct TomlFormatConfig {
     /// ```
     /// TO:
     ///
-    /// ```
+    /// ```toml
     /// [package]
     /// name = "some-crate"
     /// version = "0.0.0"
@@ -77,7 +77,7 @@ pub struct TomlFormatConfig {
 
     //// Order table keys alphabetically.
     ///
-    /// ```
+    /// ```toml
     /// [some-table]
     /// b = "b"
     /// c = "c"
@@ -86,7 +86,7 @@ pub struct TomlFormatConfig {
     ///
     /// TO:
     ///
-    /// ```
+    /// ```toml
     /// [some-table]
     /// a = "a"
     /// b = "b"
@@ -96,7 +96,7 @@ pub struct TomlFormatConfig {
     /// Order the section keys, except from package, by group then alphabetically. 
     /// A group is defined by a white space after an table item. Comments are skipped when counting whitespaces. 
     /// 
-    ///  /// ```
+    /// ```toml
     /// [some-table] 
     /// c = "b"         # <-- group 1 start
     /// a = "c"
@@ -111,7 +111,7 @@ pub struct TomlFormatConfig {
     /// ```
     ///
     /// TO:
-    /// ```
+    /// ```toml
     /// [some-table]
     /// a = "a"
     /// c = "a"
@@ -132,20 +132,20 @@ pub struct TomlFormatConfig {
 
     /// Trims empty spaces around the section names.
     ///
-    /// ```
+    /// ```toml
     /// [ package ]
     /// ```
     ///
     /// TO:
     ///
-    /// ```
+    /// ```toml
     /// [package]
     /// ```
     pub trim_section_key_names: bool,
 
     /// Trims empty spaces around to level section items their keys.
     ///
-    /// ```
+    /// ```toml
     /// [package]
     /// a = "a"
     ///
@@ -157,7 +157,7 @@ pub struct TomlFormatConfig {
     ///
     /// TO:
     ///
-    /// ```
+    /// ```toml
     /// [package]
     /// a = "a"
     /// b = "b"
@@ -168,12 +168,12 @@ pub struct TomlFormatConfig {
 
     /// Trims quotes from table keys.
     ///
-    /// ```
+    /// ```toml
     /// [package]
     /// "a" = {"a"="a"}
     /// ```
     /// TO
-    /// ```
+    /// ```toml
     /// [package]
     /// a = {a="a"}
     /// ```

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -18,7 +18,7 @@ fn mytest() {
     let toml_1 = r#"
     # test 1
     [a]
-    adep = "0.4.0"#;
+    adep = "0.4.0""#;
 
     let toml_2 = r#"    
     [a]
@@ -41,7 +41,7 @@ adep = "0.4.0"
     let mut config = TomlFormatConfig::new();
     config.order_section_keys_by_group_alphabetically = true;
 
-    let mut cargo = CargoToml::from_config(toml.to_string(), config).unwrap();
+    let mut cargo = CargoToml::from_config(toml_1.to_string(), config).unwrap();
 
     cargo.format().unwrap();
 


### PR DESCRIPTION
Fixes #4 .

Also mark the toml as such, otherwise `cargo test` tries to compile the toml as a Rust test.